### PR TITLE
feat: support `GetItemInSlot` to return a sandboxed item

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,5 @@ All other information should be explored by reading the source code!
 
 - [2023/3/21 21:13] fix: remove shop and spawn heros as a circle.([#20](https://github.com/Escapingbug/dotaxctf/pull/20))
 - [2023/3/21 22:00] feat: support getting hero's candidate id.([#21](https://github.com/Escapingbug/dotaxctf/pull/21))
-- [2023/3/22 13:30] fix: remove non-hero units after round ends.([#23](https://github.com/Escapingbug/dotaxctf/pull/23), reporter: AAA剑圣)
+- [2023/3/23 13:30] fix: remove non-hero units after round ends.([#23](https://github.com/Escapingbug/dotaxctf/pull/23), reporter: AAA剑圣)
+- [2023/3/24 00:22] feat: support `GetItemInSlot(slot)` to return a sandboxed item.([#24](https://github.com/Escapingbug/dotaxctf/pull/24))

--- a/sandbox.lua
+++ b/sandbox.lua
@@ -185,6 +185,11 @@ function Sandbox:SandboxBaseNPC(npc, readonly)
         return Sandbox:SandboxAbility(ability)
     end
 
+    function sandboxed:GetItemInSlot(slot)
+        local item = npc:GetItemInSlot(slot)
+        return Sandbox:SandboxItem(item)
+    end
+
     if readonly then
         return sandboxed
     end
@@ -274,6 +279,49 @@ function Sandbox:SandboxAbility(ability)
         GetEntityIndex            = copy_method(ability, "GetEntityIndex"),
     }
 
+    return sandboxed
+end
+
+function Sandbox:SandboxItem(item)
+    if item == nil then
+        return nil
+    end
+
+    local sandboxed = {
+        CanBeUsedOutOfInventory = copy_method(item, "CanBeUsedOutOfInventory"),
+        CanOnlyPlayerHeroPickup = copy_method(item, "CanOnlyPlayerHeroPickup"),
+
+        GetCost = copy_method(item, "GetCost"),
+        GetCurrentCharges = copy_method(item, "GetCurrentCharges"),
+        GetInitialCharges = copy_method(item, "GetInitialCharges"),
+        GetItemSlot = copy_method(item, "GetItemSlot"),
+        GetItemState = copy_method(item, "GetItemState"),
+        GetPurchaseTime = copy_method(item, "GetPurchaseTime"),
+        GetSecondaryCharges = copy_method(item, "GetSecondaryCharges"),
+        GetValuelessCharges = copy_method(item, "GetValuelessCharges"),
+
+        IsAlertableItem = copy_method(item, "IsAlertableItem"),
+        IsCastOnPickup = copy_method(item, "IsCastOnPickup"),
+        IsCombinable = copy_method(item, "IsCombinable"),
+        IsCombineLocked = copy_method(item, "IsCombineLocked"),
+        IsDisassemblable = copy_method(item, "IsDisassemblable"),
+        IsDroppable = copy_method(item, "IsDroppable"),
+        IsInBackpack = copy_method(item, "IsInBackpack"),
+        IsItem = copy_method(item, "IsItem"),
+        IsKillable = copy_method(item, "IsKillable"),
+        IsMuted = copy_method(item, "IsMuted"),
+        IsNeutralDrop = copy_method(item, "IsNeutralDrop"),
+        IsPermanent = copy_method(item, "IsPermanent"),
+        IsPurchasable = copy_method(item, "IsPurchasable"),
+        IsRecipe = copy_method(item, "IsRecipe"),
+        IsRecipeGenerated = copy_method(item, "IsRecipeGenerated"),
+        IsSellable = copy_method(item, "IsSellable"),
+        IsStackable = copy_method(item, "IsStackable"),
+
+        GetName = copy_method(item, "GetAbilityName"), -- CDOTA_Item extends CDOTABaseAbility
+
+        GetEntityIndex = copy_method(item, "GetEntityIndex"),
+    }
     return sandboxed
 end
 


### PR DESCRIPTION
Support `GetItemInSlot` to return a sandboxed item for item related orders.