### PR TITLE
refactor: use `0` for beginning score instead of score from server

### DIFF
--- a/rounds.lua
+++ b/rounds.lua
@@ -412,7 +412,7 @@ function Rounds:PrepareBeginRound()
         local round_index = self.round_count / Config.total_rounds_count
         round_index = math.min(round_index, 1) -- make sure it is not greater than 1
         for _, team in pairs(data.teams) do
-            self.scores_this_round[team.team_id] = team.score
+            self.scores_this_round[team.team_id] = 0
             chooser_scripts[team.team_id] = from_base64(team.select)
             bot_scripts[team.team_id] = from_base64(team.act)
             local rank_index = (Config.candidate_count - team.rank) / (Config.candidate_count - 1)


### PR DESCRIPTION
Use `0` for beginning score instead of score from server