### PR TITLE
fix: place history.scores updates to correct loc

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ All other information should be explored by reading the source code!
 - [2023/3/27 23:53] fix: use `npc:GetEntityIndex()` and `npc:GetTeam()` to avoid unexpect behaviors.([#27](https://github.com/Escapingbug/dotaxctf/pull/27), reporter: 114@x1ct34m)
 - [2023/3/28 09:11] fix: ban nonhero units for hero choosing.([#31](https://github.com/Escapingbug/dotaxctf/pull/31))
 - [2023/3/28 09:16] feat: clean up items when round ends.([#30](https://github.com/Escapingbug/dotaxctf/pull/30))
+- [2023/3/29 08:46] fix: place history.scores updates to correct loc.([#32](https://github.com/Escapingbug/dotaxctf/pull/32), reporter: AAA剑圣)

--- a/rounds.lua
+++ b/rounds.lua
@@ -55,6 +55,12 @@ end
 ]]
 function Rounds:FlushScoresAndRunNextRound()
     print("[xctf Rounds:FlushRoundScores]" .. "Flushing round scores")
+    
+    if self.round_count > 0 then
+        local last_scores = deepcopy(self.scores_this_round)
+        table.insert(self.history.scores, last_scores)
+    end
+
     local req = CreateHTTPRequest("POST", Config.server_url.service)
     if req == nil then
         print("[xctf Rounds:FlushRoundScores]" .. "Failed to create http request")
@@ -295,11 +301,6 @@ end
 
 function Rounds:NextRound(scripts)
     print("[xctf Rounds:NextRound()]" .. "Next Round")
-
-    if self.round_count > 0 then
-        local last_scores = deepcopy(self.scores_this_round)
-        table.insert(self.history.scores, last_scores)
-    end
 
     Rounds:CleanupLivingHerosAndClearUnits()
     Rounds:ChooseHeros(scripts["chooser_scripts"], scripts["attributes"], scripts["bot_scripts"])


### PR DESCRIPTION
The existing `GetHistoryScores` is broken, which only returns base scores due to the buggy update of the history score. Place the history update to `FlushScoresAndRunNextRound` seems workable