### PR TITLE
fix: remove entities between rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,4 @@ All other information should be explored by reading the source code!
 - [2023/3/29 08:46] fix: place history.scores updates to correct loc.([#32](https://github.com/Escapingbug/dotaxctf/pull/32), reporter: AAA剑圣)
 - [2023/3/29 11:18] feat: print with `[Sandbox.candidate_name]` banner to support checking specified hero's log.([#33](https://github.com/Escapingbug/dotaxctf/pull/33))
 - [2023/3/29 15:26] feat: print with `[Sandbox.candidate_name.script]` banner when script got an error.([#35](https://github.com/Escapingbug/dotaxctf/pull/35))
+- [2023/3/29 21:44] feat: remove all nonempty entities after round ends.([#36](https://github.com/Escapingbug/dotaxctf/pull/36))

--- a/rounds.lua
+++ b/rounds.lua
@@ -219,9 +219,13 @@ function Rounds:InitFromServerAndBeginGame()
 end
 
 function Rounds:CleanupLivingHerosAndClearUnits()
-    for _, hero in pairs(self.heros) do
-        hero:RemoveSelf()
+    local entities = Entities:FindAllInSphere(Vector(0, 0), 1e6)
+    for _, entity in ipairs(entities) do
+        if entity:GetName() ~= "" then
+            entity:RemoveSelf()
+        end
     end
+
     self.heros = {}
 
     for _, team in pairs(AVAILABLE_TEAMS) do

--- a/sandbox.lua
+++ b/sandbox.lua
@@ -15,7 +15,6 @@ function Sandbox:Init()
     self.public_api = self:SandboxPublicAPI()
     self.default_hero = "npc_dota_hero_axe"
     self.init = true
-    self.items = {}
 end
 
 function Sandbox:SetupGameInfo(game_info)
@@ -243,7 +242,6 @@ function Sandbox:SandboxBaseNPC(npc, readonly)
         -- we only use unreliable gold
         npc:SetGold(gold_left, false)
         npc:AddItem(item)
-        table.insert(Sandbox.items, item)
         return true
     end
 
@@ -335,11 +333,6 @@ function Sandbox:SandboxItem(item)
 end
 
 function Sandbox:CleanUpItems()
-    for _, item in ipairs(self.items) do
-        item:RemoveSelf()
-    end
-    self.items = {}
-
     local total = GameRules:NumDroppedItems()
     for _ = 1, total do
         GameRules:GetDroppedItem(0):RemoveSelf()


### PR DESCRIPTION
Remove all nonempty entities after round ends.