### PR TITLE
feat: update panel state when round ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ All other information should be explored by reading the source code!
 - [2023/3/29 08:46] fix: place history.scores updates to correct loc.([#32](https://github.com/Escapingbug/dotaxctf/pull/32), reporter: AAA剑圣)
 - [2023/3/29 11:18] feat: print with `[Sandbox.candidate_name]` banner to support checking specified hero's log.([#33](https://github.com/Escapingbug/dotaxctf/pull/33))
 - [2023/3/29 15:26] feat: print with `[Sandbox.candidate_name.script]` banner when script got an error.([#35](https://github.com/Escapingbug/dotaxctf/pull/35))
-- [2023/3/29 21:44] feat: remove all nonempty entities after round ends.([#36](https://github.com/Escapingbug/dotaxctf/pull/36))
+- [2023/3/29 21:44] fix: remove all nonempty entities after round ends.([#36](https://github.com/Escapingbug/dotaxctf/pull/36))
+- [2023/3/29 22:49] feat: update panel state when round ends.([#37](https://github.com/Escapingbug/dotaxctf/pull/37))

--- a/rounds.lua
+++ b/rounds.lua
@@ -50,6 +50,16 @@ function Rounds:UpdateScoresPanel()
     )
 end
 
+function Rounds:UpdateRoundEndPanel()
+    local event = {
+        round_count = self.round_count
+    }
+    CustomGameEventManager:Send_ServerToAllClients(
+        "roundEnd",
+        event
+    )
+end
+
 --[[
     Send scores to server and reset to 0
 ]]
@@ -541,6 +551,7 @@ function Rounds:BeginRound(bot_scripts)
             callback = function ()
                 Timers:RemoveTimer("round_periodic_timer")
                 Rounds:RoundEndedScoring()
+                Rounds:UpdateRoundEndPanel()
                 Rounds:FlushScoresAndRunNextRound()
                 Sandbox:CleanUpItems()
             end
@@ -556,6 +567,7 @@ function Rounds:BeginRound(bot_scripts)
                 if #living_teams <= 1 then
                     Timers:RemoveTimer("round_limit_timer")
                     Rounds:RoundEndedScoring()
+                    Rounds:UpdateRoundEndPanel()
                     Rounds:FlushScoresAndRunNextRound()
                     Sandbox:CleanUpItems()
                     return


### PR DESCRIPTION
Update panel state to `第 ${event.round_count} 轮结束` when round ends.

https://github.com/Escapingbug/dotaxctf-contents/pull/2