### PR TITLE
feat: print with `[Sandbox.candidate_name.script.load]` banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ All other information should be explored by reading the source code!
 - [2023/3/29 15:26] feat: print with `[Sandbox.candidate_name.script]` banner when script got an error.([#35](https://github.com/Escapingbug/dotaxctf/pull/35))
 - [2023/3/29 21:44] fix: remove all nonempty entities after round ends.([#36](https://github.com/Escapingbug/dotaxctf/pull/36))
 - [2023/3/29 22:49] feat: update panel state when round ends.([#37](https://github.com/Escapingbug/dotaxctf/pull/37))
+- [2023/3/30 02:43] feat: print with `[Sandbox.candidate_name.script.load]` banner for loading error log.([#38](https://github.com/Escapingbug/dotaxctf/pull/38))

--- a/sandbox.lua
+++ b/sandbox.lua
@@ -37,7 +37,7 @@ function Sandbox:LoadScript(user_script, quota, env, candidate_name)
     }
     local results = {pcall(lua_sandbox.protect, user_script, options)}
     if not results[1] then
-        print("load script error: " .. results[2])
+        print("[Sandbox.".. candidate_name ..".script.load]", results[2])
         return nil
     end
     return results[2]
@@ -49,7 +49,7 @@ function Sandbox:RunFunctionWrap(func, candidate_name, ...)
     end
     local results = {pcall(func, ...)}
     if not results[1] then
-        print("[Sandbox.".. candidate_name ..".script]", results[2])
+        print("[Sandbox.".. candidate_name ..".script.run]", results[2])
         return nil
     end
     return results[2]


### PR DESCRIPTION
Print with `[Sandbox.candidate_name.script.load]` banner for error log.